### PR TITLE
Fix BubbleV1Raffle::getRemainingTimeUntilNextEpoch() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ Distributed under the MIT License. See `LICENSE.txt` for more information.
 ## Reach Out
 
 [![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white)][discord-url]
-
 [![X](https://img.shields.io/badge/X-%23000000.svg?style=for-the-badge&logo=X&logoColor=white)][x-url]
 
 

--- a/src/raffle/BubbleV1Raffle.sol
+++ b/src/raffle/BubbleV1Raffle.sol
@@ -691,6 +691,8 @@ contract BubbleV1Raffle is ERC721, Ownable, IEntropyConsumer, IBubbleV1Raffle {
     /// @notice Gets the time remaining until the next epoch.
     /// @return The time remaining until the next epoch.
     function getTimeRemainingUntilNextEpoch() external view returns (uint256) {
+        if (block.timestamp - s_lastDrawTimestamp > EPOCH_DURATION) return 0;
+
         return EPOCH_DURATION - (block.timestamp - s_lastDrawTimestamp);
     }
 


### PR DESCRIPTION
Fix the function so it returns 0 instead of reverting when the time passed since last draw is greater than the raffle epoch duration