### PR TITLE
Refactor the BubbleV1Raffle::getNftToRange() function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,13 @@ precommit :; forge fmt && git add .
 
 anvil :; anvil -m 'test test test test test test test test test test test junk' --steps-tracing --block-time 1
 
+sync-branches :; git switch audit && git pull origin main && git push \
+	git switch review && git pull origin main && git push \
+	git switch fix && git pull origin main && git push \
+	git switch developer_s01 && git pull origin main && git push \
+	git switch developer_h02 && git pull origin main && git push \
+	git switch testing && git pull origin main && git push
+
 deploy-protocol-without-governance-local :; forge script script/DeployProtocolWithoutGovernance.s.sol \
 	--broadcast \
 	--rpc-url "127.0.0.1:8545" \

--- a/src/interfaces/IBubbleV1Raffle.sol
+++ b/src/interfaces/IBubbleV1Raffle.sol
@@ -79,6 +79,8 @@ interface IBubbleV1Raffle {
 
     function getNftToRange(uint256 _tokenId) external view returns (uint256[] memory);
 
+    function getNftToRange(uint256[] memory _tokenIds) external view returns (uint256[][] memory);
+
     function getEpochToRangeEndingPoint(uint256 _epoch) external view returns (uint256);
 
     function getTokenAmountCollectedInEpoch(

--- a/src/raffle/BubbleV1Raffle.sol
+++ b/src/raffle/BubbleV1Raffle.sol
@@ -630,6 +630,20 @@ contract BubbleV1Raffle is ERC721, Ownable, IEntropyConsumer, IBubbleV1Raffle {
         return s_nftToRange[_tokenId];
     }
 
+    /// @notice Gets the range occupied by a raffle Nft in an epoch.
+    /// @param _tokenIds The raffle Nft tokenId.
+    /// @return The range occupied by the Nft tokenId.
+    function getNftToRange(uint256[] memory _tokenIds) external view returns (uint256[][] memory) {
+        uint256 length = _tokenIds.length;
+        uint256[][] memory nftRanges = new uint256[][](length);
+
+        for (uint256 i; i < length; ++i) {
+            nftRanges[i] = s_nftToRange[_tokenIds[i]];
+        }
+
+        return nftRanges;
+    }
+
     /// @notice Gets the epoch range ending point.
     /// @param _epoch The epoch number.
     /// @return The range ending point for a given epoch.


### PR DESCRIPTION
Override the BubbleV1Raffle::getNftToRange() function so that it returns the ranges occupied by an array of nft tokenIds